### PR TITLE
Prevent scrolling of table body relative to table header (+remove associated scrollbar)

### DIFF
--- a/test1.html
+++ b/test1.html
@@ -88,14 +88,14 @@
 </head>
 <body>
 
-    <h3>With nested divs</h3>
+<h3>With nested divs</h3>
 
-    <div id="constrainer">
-        <div class="scrolltable">
+<div id="constrainer">
+    <div class="scrolltable">
         <table class="header"><thead><th>foo</th><th>foo</th><th>foo</th><th>foo</th></thead></table>
-            <div class="body">
-                <table>
-                    <tbody>
+        <div class="body">
+            <table>
+                <tbody>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
@@ -127,20 +127,20 @@
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
-                    </tbody>
-                </table>
-            </div>
+                </tbody>
+            </table>
         </div>
     </div>
+</div>
 
 
-    <h3>No nested divs</h3>
-    <div id="constrainer2">
-        <table>
-            <thead>
+<h3>No nested divs</h3>
+<div id="constrainer2">
+    <table>
+        <thead>
         <th>foo</th><th>foo</th><th>foo</th><th>foo</th>
-            </thead>
-            <tbody>
+        </thead>
+        <tbody>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
@@ -172,9 +172,9 @@
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
-            </tbody>
-        </table>
-    </div>
+        </tbody>
+    </table>
+</div>
 
 
 </body>

--- a/test1.html
+++ b/test1.html
@@ -48,7 +48,7 @@
             overflow-y: scroll;
         }
         #constrainer2 tbody {
-            overflow-x: scroll;
+            overflow-x: hidden;
             display: block;
             height: 200px;
         }
@@ -88,14 +88,14 @@
 </head>
 <body>
 
-<h3>With nested divs</h3>
+    <h3>With nested divs</h3>
 
-<div id="constrainer">
-    <div class="scrolltable">
+    <div id="constrainer">
+        <div class="scrolltable">
         <table class="header"><thead><th>foo</th><th>foo</th><th>foo</th><th>foo</th></thead></table>
-        <div class="body">
-            <table>
-                <tbody>
+            <div class="body">
+                <table>
+                    <tbody>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
@@ -127,20 +127,20 @@
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
                 <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
-                </tbody>
-            </table>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
-</div>
 
 
-<h3>No nested divs</h3>
-<div id="constrainer2">
-    <table>
-        <thead>
+    <h3>No nested divs</h3>
+    <div id="constrainer2">
+        <table>
+            <thead>
         <th>foo</th><th>foo</th><th>foo</th><th>foo</th>
-        </thead>
-        <tbody>
+            </thead>
+            <tbody>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
@@ -172,9 +172,9 @@
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
         <tr><td>foo</td><td>foo</td><td>foo</td><td>foo</td></tr>
-        </tbody>
-    </table>
-</div>
+            </tbody>
+        </table>
+    </div>
 
 
 </body>


### PR DESCRIPTION
Hi - this is my very first pull request ever, anywhere, so if I'm making some gaffes please bear with me :)

With your current version, the 2nd implementation shows two overflow-x scrollbars (see first attached image). One of them is for the tbody relative to table header, and scrolling of the tbody relative to the header is allowed. But this is not wanted, is it? Kind of defeats the purpose of the header, if it's not aligned with the body :).

Setting #constrainer2 tbody { overflow-x: hidden } instead of { overflow-x: scroll } fixes this (see attached image #2).

![screen shot 2018-08-07 at 15 06 17](https://user-images.githubusercontent.com/12274643/43777582-848f9d9e-9a53-11e8-8e46-4a5f755400e8.png)
![screen shot 2018-08-07 at 14 57 01](https://user-images.githubusercontent.com/12274643/43777589-8a826326-9a53-11e8-90ed-692d6cb58468.png)
